### PR TITLE
Use category for text translation requests and react well when invalid category is used.

### DIFF
--- a/DocumentTranslation.GUI/MainWindow.xaml
+++ b/DocumentTranslation.GUI/MainWindow.xaml
@@ -74,7 +74,7 @@
                     </StatusBar>
                 </Grid>
             </TabItem>
-            <TabItem Header="{x:Static resx:Resources.tabTitle_TranslateText}" Width="200" x:Name="TranslateTextTab">
+            <TabItem Header="{x:Static resx:Resources.tabTitle_TranslateText}" Width="200" x:Name="TranslateTextTab" Loaded="TranslateTextTab_Loaded">
                 <Grid>
                     <StackPanel x:Name="Fields" Orientation="Horizontal" Margin="20" Height="22" VerticalAlignment="Top" Grid.ColumnSpan="2">
                         <Label Content="{x:Static resx:Resources.label_From}" HorizontalAlignment="Left" VerticalAlignment="Top"  Margin="0,0,10,0" Padding="2"/>
@@ -85,7 +85,7 @@
                         <ComboBox x:Name="CategoryTextBox" HorizontalAlignment="Right"  VerticalAlignment="Top" Width="150" DisplayMemberPath="Name" SelectedValuePath="Name" SelectionChanged="CategoryTextBox_SelectionChanged" ToolTip="{x:Static resx:Resources.tooltip_Category}"/>
                         <Button x:Name="CategoryTextClearButton" Content="{x:Static resx:Resources.button_Clear}" HorizontalAlignment="Right"  VerticalAlignment="Top" Margin="10,0" Visibility="Hidden" Padding="2" Click="CategoryTextClearButton_Click" ToolTip="{x:Static resx:Resources.tooltip_CategoryClear}"/>
                     </StackPanel>
-                    <Grid Margin="20,50,20,10" Grid.ColumnSpan="2">
+                    <Grid Margin="20,50,20,25" Grid.ColumnSpan="2">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="25"/>
                             <RowDefinition/>
@@ -104,6 +104,12 @@
                             <Button x:Name="translateButton" Content="{x:Static resx:Resources.button_Translate}" Width="100" Click="TranslateButton_Click" Padding="2"/>
                         </StackPanel>
                     </Grid>
+                    <StatusBar VerticalAlignment="Bottom">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock x:Name="StatusBarTText1" Margin="10,0,0,0"/>
+                            <TextBlock x:Name="StatusBarTText2" Margin="10,0,0,0"/>
+                        </StackPanel>
+                    </StatusBar>
                 </Grid>
             </TabItem>
             <TabItem Header="{x:Static resx:Resources.tabTitle_Settings}" Width="200" x:Name="SettingsTab">

--- a/DocumentTranslation.GUI/MainWindow.xaml.cs
+++ b/DocumentTranslation.GUI/MainWindow.xaml.cs
@@ -96,11 +96,20 @@ namespace DocumentTranslation.GUI
 
         private async void TranslateButton_Click(object sender, RoutedEventArgs e)
         {
-            if (CategoryTextBox.SelectedItem is not null)
-                ViewModel.textTranslationService.CategoryID = ((MyCategory)CategoryTextBox.SelectedItem).ID;
-            else
-                ViewModel.textTranslationService.CategoryID = null;
-            outputBox.Text = await ViewModel.TranslateTextAsync(inputBox.Text, fromLanguageBox.SelectedValue as string, toLanguageBox.SelectedValue as string);
+            ViewModel.textTranslationService.CategoryID = CategoryTextBox.SelectedItem is not null ? ((MyCategory)CategoryTextBox.SelectedItem).ID : null;
+            try
+            {
+                outputBox.Text = await ViewModel.TranslateTextAsync(inputBox.Text, fromLanguageBox.SelectedValue as string, toLanguageBox.SelectedValue as string);
+            }
+            catch (InvalidCategoryException)
+            {
+                outputBox.Text = string.Empty;
+                StatusBarTText1.Text = Properties.Resources.msg_TranslateButton_Click_Error;
+                StatusBarTText1.Text = Properties.Resources.msg_TranslateButton_Click_InvalidCategory;
+                await Task.Delay(2000);
+                StatusBarTText1.Text = string.Empty;
+                StatusBarTText1.Text = string.Empty;
+            }
         }
 
         private void DocumentBrowseButton_Click(object sender, RoutedEventArgs e)
@@ -407,6 +416,11 @@ namespace DocumentTranslation.GUI
                 outputBox.FlowDirection = System.Windows.FlowDirection.LeftToRight;
                 outputBox.TextAlignment = TextAlignment.Left;
             }
+        }
+
+        private void TranslateTextTab_Loaded(object sender, RoutedEventArgs e)
+        {
+
         }
     }
 }

--- a/DocumentTranslation.GUI/MainWindow.xaml.cs
+++ b/DocumentTranslation.GUI/MainWindow.xaml.cs
@@ -96,6 +96,10 @@ namespace DocumentTranslation.GUI
 
         private async void TranslateButton_Click(object sender, RoutedEventArgs e)
         {
+            if (CategoryTextBox.SelectedItem is not null)
+                ViewModel.textTranslationService.CategoryID = ((MyCategory)CategoryTextBox.SelectedItem).ID;
+            else
+                ViewModel.textTranslationService.CategoryID = null;
             outputBox.Text = await ViewModel.TranslateTextAsync(inputBox.Text, fromLanguageBox.SelectedValue as string, toLanguageBox.SelectedValue as string);
         }
 

--- a/DocumentTranslation.GUI/Properties/Resources.Designer.cs
+++ b/DocumentTranslation.GUI/Properties/Resources.Designer.cs
@@ -430,6 +430,24 @@ namespace DocumentTranslation.GUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error.
+        /// </summary>
+        public static string msg_TranslateButton_Click_Error {
+            get {
+                return ResourceManager.GetString("msg_TranslateButton_Click_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid Category.
+        /// </summary>
+        public static string msg_TranslateButton_Click_InvalidCategory {
+            get {
+                return ResourceManager.GetString("msg_TranslateButton_Click_InvalidCategory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Waiting: .
         /// </summary>
         public static string msg_Waiting {

--- a/DocumentTranslation.GUI/Properties/Resources.resx
+++ b/DocumentTranslation.GUI/Properties/Resources.resx
@@ -240,6 +240,12 @@
   <data name="msg_TestPassed" xml:space="preserve">
     <value>Test passed</value>
   </data>
+  <data name="msg_TranslateButton_Click_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="msg_TranslateButton_Click_InvalidCategory" xml:space="preserve">
+    <value>Invalid Category</value>
+  </data>
   <data name="msg_Waiting" xml:space="preserve">
     <value>Waiting: </value>
   </data>

--- a/DocumentTranslationService.Core/InvalidCategoryException.cs
+++ b/DocumentTranslationService.Core/InvalidCategoryException.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Text Translation Service Facade
+ */
+
+using System;
+using System.Runtime.Serialization;
+
+namespace DocumentTranslationService.Core
+{
+    /// <summary>
+    /// Throws when an invalid categoryID value is encountered
+    /// </summary>
+    [Serializable]
+    public class InvalidCategoryException : Exception
+    {
+        public InvalidCategoryException()
+        {
+        }
+
+        public InvalidCategoryException(string message) : base(message)
+        {
+        }
+
+        public InvalidCategoryException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected InvalidCategoryException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/DocumentTranslationService.Core/TextTranslationService.cs
+++ b/DocumentTranslationService.Core/TextTranslationService.cs
@@ -445,10 +445,12 @@ namespace DocumentTranslationService.Core
                     continue;
                 }
                 int status = (int)response.StatusCode;
+                if (status != 200) Debug.WriteLine($"TranslateText error: {response.ReasonPhrase}");
                 switch (status)
                 {
                     case 200:
                         break;
+                    case 400: throw new InvalidCategoryException(category);
                     case 401: throw new AccessViolationException("Invalid credentials. Check for key/region mismatch.");
                     case 408:       //Custom system is being loaded
                         Debug.WriteLine("Retry #" + retrycount + " Response: " + (int)response.StatusCode);

--- a/DocumentTranslationService.Core/TextTranslationService.cs
+++ b/DocumentTranslationService.Core/TextTranslationService.cs
@@ -1,15 +1,6 @@
-﻿// // ----------------------------------------------------------------------
-// // <copyright file="TranslationServiceFacade.cs" company="Microsoft Corporation">
-// // Copyright (c) Microsoft Corporation.
-// // All rights reserved.
-// // THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY
-// // KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-// // IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-// // PARTICULAR PURPOSE.
-// // </copyright>
-// // ----------------------------------------------------------------------
-// // <summary>TranslationServiceFacade.cs</summary>
-// // ----------------------------------------------------------------------
+﻿/*
+ * Text Translation Service Facade
+ */
 
 #region Usings
 using System;
@@ -28,7 +19,7 @@ namespace DocumentTranslationService.Core
 
     public class TextTranslationService
     {
-        #region Fields
+        #region Properties and fields
 
         private const int MillisecondsTimeout = 100;
 
@@ -38,8 +29,10 @@ namespace DocumentTranslationService.Core
         private const int maxelements = 100;
         private readonly DocumentTranslationService documentTranslationService;
 
-        private string categoryID;
-
+        /// <summary>
+        /// The category ID to use
+        /// </summary>
+        public string CategoryID { get; set; }
         /// <summary>
         /// End point address for the Translator API
         /// </summary>
@@ -48,9 +41,6 @@ namespace DocumentTranslationService.Core
         public static int Maxelements { get => maxelements; }
         public string AzureRegion { get; set; } = null;
         public string AzureCloud { get; set; } = String.Empty;
-        /// <summary>
-        /// Indicates whether the translation service has been successfully initialized.
-        /// </summary>
 
         public enum ContentType { plain, HTML };
         #endregion
@@ -143,9 +133,7 @@ namespace DocumentTranslationService.Core
                 {
                     string[] teststring = { "Test" };
                     string remembercategory = documentTranslationService.Category;
-                    categoryID = category;
-                    Task<string[]> translateTask = TranslateTextAsync(teststring, "en", "he");
-                    categoryID = remembercategory;
+                    Task<string[]> translateTask = TranslateTextAsyncInternal(teststring, "en", "he", category, ContentType.plain);
                     await translateTask.ConfigureAwait(false);
                     if (translateTask.Result == null) return false; else return true;
                 }
@@ -167,7 +155,7 @@ namespace DocumentTranslationService.Core
         public TextTranslationService(DocumentTranslationService documentTranslationService)
         {
             this.documentTranslationService = documentTranslationService;
-            this.categoryID = documentTranslationService.Category;
+            this.CategoryID = documentTranslationService.Category;
         }
 
 
@@ -371,7 +359,7 @@ namespace DocumentTranslationService.Core
                     {
                         string[] str = new string[1];
                         str[0] = innertext;
-                        string[] innertranslation = await TranslateTextAsyncInternal(str, from, to, categoryID, contentType).ConfigureAwait(false);
+                        string[] innertranslation = await TranslateTextAsyncInternal(str, from, to, CategoryID, contentType).ConfigureAwait(false);
                         linetranslation += innertranslation[0];
                     }
                     resultlist.Add(linetranslation);
@@ -380,7 +368,7 @@ namespace DocumentTranslationService.Core
             }
             else
             {
-                return await TranslateTextAsyncInternal(texts, from, to, categoryID, contentType).ConfigureAwait(false);
+                return await TranslateTextAsyncInternal(texts, from, to, CategoryID, contentType).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Closes #35.
Adds a status bar in the text translation tab to indicate a failed category. 